### PR TITLE
Template update according to the "Awin template needed updates" document

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 There are two types of events that Awin tag supports: PageView and Conversion. 
 
-- **PageView event** stores the awc URL parameter inside the awin_awc cookie. 
+- **PageView event** stores the `awc` URL parameter inside the `awin_awc` or `awin_sn_awc` cookie, and the source (usually, the `utm_source` value) inside the `awin_source` cookie. 
 - **Conversion event** sends the HTTP request with the specified conversion data to Awin.
 
 ## How to use the Awin tag:
 
-1. Create an Awin tag and add Page View and Purchase triggers
+1. Create an Awin tag and add Page View and Purchase triggers.
 2. Add the only required field for the conversion event - Merchant ID, other fields are optional.
 
-**Merchant ID** - advertiser program ID
+**Merchant ID** - advertiser program ID.
 
 **Order Reference** - booking or transaction ID.
 

--- a/README.md
+++ b/README.md
@@ -10,23 +10,35 @@ There are two types of events that Awin tag supports: PageView and Conversion.
 1. Create an Awin tag and add Page View and Purchase triggers
 2. Add the only required field for the conversion event - Merchant ID, other fields are optional.
 
-**Merchant ID** -  advertiser program ID
+**Merchant ID** - advertiser program ID
 
 **Order Reference** - booking or transaction ID.
 
 **Total Order Value** - value excluding taxes, delivery, and discounts. For a lead-based campaign or program, the value should be the number of leads; for example, "1". Tag will ignore the value if multiple commission groups are specified in the Commission Group Code field.
 
-**Currency Code** -  currency code in ISO standard (e.g., "GBP").
+**Currency Code** - currency code in ISO standard (e.g., "GBP").
 
-**Commission Group Code** - The code for the commission group you want to base the commission calculation on. The value can be either a single group name (e.g., "CD") or a complete set of groups and the commission value for each group (e.g., "CD:11.10|DVD:14.99").
+**Commission Group Code** -the code for the commission group you want to base the commission calculation on. The value can be either a single group name (e.g., "CD") or a complete set of groups and the commission value for each group (e.g., "CD:11.10|DVD:14.99").
 
 **Discount Code** - promo code applied on the check-out.
 
-**Last Paid Click Referring Channel** - The value utilized to determine how AWIN should process the incoming transaction requests.
+**Last Paid Click Referring Channel** - the value utilized to determine how AWIN should process the incoming transaction requests.
+
+**Discount Code** - promo code applied on the check-out.
+
+**Products Override** - override items array to be used by the tag.
+
+**Automatically detect consent from Google Consent Mode or Stape's Data Tag** - if you are using Google Consent Mode or Stape's Data Tag to transmit consent to the server.
+
+**Awin Consent Signal** - manual field to supply consent information.
+
+**Enable Unconditional Cashback & Rewards Tracking** - option to exempt Cashback and Rewards Journeys from consent restrictions.
 
 **Awin Click ID** - optional, can be used to override click ID from cookie.
 
 **In test mode** - use to test the setup. Conversion in the test mode will be ignored.
+
+**Override the cookie domain** - optional, can be used to override the default domain where cookies are set.
 
 
 ### Useful links:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: 'https://stape.io/'
 versions:
+  - sha: 36c09751c354293319649ab03cc4ff36886ce2c2
+    changeNotes: Improved consent framework, improved PLT tracking, improved custom parameters handling, added cookie domain override, added some tests.
   - sha: 80a94cf14d27ea976655f46e25c45a598afde6c8
     changeNotes: Added Awin click ID override option, fixed cookie http_only, fixed gtm-msr.appspot.com requests.
   - sha: d193e263ffb75a68110db19499da45af23797c1d

--- a/template.js
+++ b/template.js
@@ -1,4 +1,4 @@
-﻿const sendHttpRequest = require('sendHttpRequest');
+const sendHttpRequest = require('sendHttpRequest');
 const setCookie = require('setCookie');
 const parseUrl = require('parseUrl');
 const JSON = require('JSON');
@@ -19,8 +19,8 @@ const eventName = eventData.event_name;
 
 const PAGE_VIEW_EVENT = data.pageViewEvent || 'page_view';
 const PURCHASE_EVENT = data.purchaseEvent || 'purchase';
-const url = getEventData('page_location') || getRequestHeader('referer');
 
+const url = getEventData('page_location') || getRequestHeader('referer');
 
 if (url && url.lastIndexOf('https://gtm-msr.appspot.com/', 0) === 0) {
   return data.gtmOnSuccess();
@@ -28,60 +28,87 @@ if (url && url.lastIndexOf('https://gtm-msr.appspot.com/', 0) === 0) {
 
 switch (eventName) {
   case PAGE_VIEW_EVENT:
-    
-
     if (url) {
       const searchParams = parseUrl(url).searchParams;
-      const deduplicationParamName =
-        data.deduplicationQueryParameterName || 'source';
-      if (searchParams.awc) {
-        const options = {
-          domain: 'auto',
-          path: '/',
-          secure: true,
-          httpOnly: false,
-          'max-age': 31536000, // 1 year
-        };
-
-        setCookie('awin_awc', searchParams.awc, options, false);
-      }
-      if (searchParams[deduplicationParamName]) {
-        const options = {
-          domain: 'auto',
-          path: '/',
-          secure: true,
-          httpOnly: false,
-          'max-age': 31536000, // 1 year
-        };
-
-        setCookie(
-          'awin_source',
-          searchParams[deduplicationParamName],
-          options,
-          false
-        );
+      const isJourneyExemptFromConsent = 
+         !!searchParams.sn && searchParams.sn === '1' && data.enableCashbackTracking;
+      const deduplicationParamName = data.deduplicationQueryParameterName || 'source';
+      
+      if (isJourneyExemptFromConsent || !isConsentDeclined()) {
+        if (searchParams.awc || (searchParams.awaid && searchParams.gclid)) {
+          const awcCookieName = isJourneyExemptFromConsent ? 'awin_sn_awc' : 'awin_awc'; 
+          const awcCookieValue = searchParams.awc 
+            ? searchParams.awc 
+            : 'gclid_' + searchParams.awaid + '_' + searchParams.gclid;
+          
+          const options = {
+            domain: data.overridenCookieDomain || 'auto',
+            path: '/',
+            secure: true,
+            httpOnly: false,
+            'max-age': 31536000, // 1 year
+          };
+          
+          setCookie(awcCookieName, awcCookieValue, options, false);
+        }
+       
+        if (searchParams[deduplicationParamName]) {
+          const options = {
+            domain: data.overridenCookieDomain || 'auto',
+            path: '/',
+            secure: true,
+            httpOnly: false,
+            'max-age': 31536000, // 1 year
+          };
+          
+          setCookie(
+            'awin_source',
+            searchParams[deduplicationParamName],
+            options,
+            false
+          );
+        }
       }
     }
-
+    
     data.gtmOnSuccess();
     break;
   case PURCHASE_EVENT:
-    const consentSignal = makeString(data.consentSignal || '');
-    const consentDeclined = ['0', 'false'].indexOf(consentSignal) !== -1;
-    const awc = consentDeclined ? '' : data.clickId || getCookieValues('awin_awc')[0] || '';
-    const source = getCookieValues('awin_source')[0];
+    const commonCookie = eventData.common_cookie || {};
+    
+    let awc;
+    let source = data.channel || getCookieValues('awin_source')[0] || commonCookie.awin_source || 'aw';
+    
+    if (!isConsentDeclined()) {
+      const awcFromCookie = 
+        [getCookieValues('awin_awc')[0], getCookieValues('awin_sn_awc')[0]]
+        .filter(cookieValue => !!cookieValue)
+        .join(',');
+      const awcFromCommonCookie = 
+        [commonCookie.awin_awc, commonCookie.awin_sn_awc]
+        .filter(cookieValue => !!cookieValue)
+        .join(',');
+      awc = data.clickId || awcFromCookie || awcFromCommonCookie;
+    } else if (data.enableCashbackTracking) {
+      awc = data.clickId || getCookieValues('awin_sn_awc')[0] || commonCookie.awin_sn_awc || '';
+    } else {
+      // Do not read the cookies or use the template fields.
+      awc = '';
+      source = '';
+    }    
+    
+    const orderReference = data.orderReference || eventData.transaction_id;
     let requestUrl =
       'https://www.awin1.com/sread.php?tt=ss&tv=2&merchant=' +
       enc(data.advertiserId);
     requestUrl = requestUrl + '&amount=' + enc(data.totalAmount);
-    requestUrl = requestUrl + '&ch=' + enc(data.channel || source || 'aw');
+    requestUrl = requestUrl + '&ch=' + enc(source);
     requestUrl = requestUrl + '&vc=' + enc(data.voucherCode);
     requestUrl = requestUrl + '&cr=' + enc(data.currencyCode);
-    requestUrl = requestUrl + '&ref=' + enc(data.orderReference);
+    requestUrl = requestUrl + '&ref=' + enc(orderReference);
     requestUrl =
       requestUrl + '&customeracquisition=' + enc(data.customerAcquisition);
     requestUrl = requestUrl + '&testmode=' + (data.isTest ? 1 : 0);
-
     requestUrl = requestUrl + '&cks=' + enc(awc);
 
     /**
@@ -102,27 +129,36 @@ switch (eventName) {
     /**
      * Custom Parameters
      */
-    const customParameters = ['gtm_s2s_stape'];
+    const customParameters = [ { key: '1', value: 'gtm_s2s_stape_' + getContainerVersion().containerId } ];
     const allowedTypesForCustomParameters = ['string', 'number', 'boolean'];
     if (getType(data.customParameters) === 'array') {
-      data.customParameters.forEach((customParameter) => {
-        customParameters.push(customParameter.value);
+      data.customParameters.forEach((customParameter, index) => {
+        customParameters.push({ 
+          // If user hasn't added the key because of the breaking change when the column was added, 
+          // we assign it on their behalf based on the order of the parameters.
+          // "key" must start at 1, and 1 is always the "gtm_s2s_stape_<Container ID>" param. So, we add 2 to the index.
+          key: customParameter.key ? customParameter.key : (index + 2), 
+          value: customParameter.value 
+        });
       });
     }
-    customParameters.forEach((customParameter, index) => {
+    customParameters.forEach((customParameter) => {
       if (
-        allowedTypesForCustomParameters.indexOf(getType(customParameter)) !== -1
+        allowedTypesForCustomParameters.indexOf(getType(customParameter.value)) !== -1
       ) {
-        requestUrl = requestUrl + '&p' + (index + 1) + '=' + customParameter;
+        requestUrl = requestUrl + '&p' + customParameter.key + '=' + enc(customParameter.value);
       }
     });
 
     /**
      * Product Level Tracking
      */
-    const items = data.productsOverride || eventData.items || [];
+    let items = data.productsOverride || eventData.items || [];
+    if (getType(items) === 'string') items = JSON.parse(items);
+    
     const productRow =
       'AW:P|{{advertiserId}}|{{orderReference}}|{{productId}}|{{productName}}|{{productItemPrice}}|{{productQuantity}}|{{productSku}}|{{commissionGroupCode}}|{{productCategory}}';
+    
     if (getType(items) === 'array') {
       items.forEach((item, index) => {
         let value = productRow.replace(
@@ -131,10 +167,13 @@ switch (eventName) {
         );
         value = value.replace(
           '{{orderReference}}',
-          enc(item.order_reference || eventData.transaction_id || '')
+          enc(orderReference || item.order_reference || '')
         );
         value = value.replace('{{productId}}', enc(item.item_id || ''));
-        value = value.replace('{{productName}}', enc(item.item_name || ''));
+        value = value.replace(
+          '{{productName}}',
+          enc(replacePipeWithUnderscore(item.item_name))
+        );
         value = value.replace(
           '{{productItemPrice}}',
           getPriceString(item.price)
@@ -150,7 +189,7 @@ switch (eventName) {
         );
         value = value.replace(
           '{{productCategory}}',
-          enc(item.item_category || '')
+          enc(replacePipeWithUnderscore(item.item_category))
         );
         requestUrl = requestUrl + '&bd[' + index + ']=' + value;
       });
@@ -198,6 +237,32 @@ switch (eventName) {
   default:
     data.gtmOnSuccess();
     break;
+}
+
+function isConsentDeclined() {
+  const autoConsentParameter = data.consentAutoDetectionParameter;
+  if (autoConsentParameter) {
+    // Check consent state from Stape's Data Tag
+    if (eventData.consent_state && eventData.consent_state[autoConsentParameter] === false) {
+      return true;
+    }
+      
+    // Check consent state from Google Consent Mode
+    const gcsPositionMapping = { analytics_storage: 3, ad_storage: 2 };
+    const xGaGcs = eventData['x-ga-gcs'] || ''; // x-ga-gcs is a string like "G110"
+    if (xGaGcs[gcsPositionMapping[autoConsentParameter]] === '0') {
+      return true;
+    }
+  }
+  
+  // Check template field specific consent signal
+  const awinConsentSignal = makeString(data.awinConsentSignal || '');
+  return ['0', 'false'].indexOf(awinConsentSignal) !== -1;
+}
+
+function replacePipeWithUnderscore(data) {
+  data = data || '';
+  return data.split('|').join('_');
 }
 
 function enc(data) {

--- a/template.tpl
+++ b/template.tpl
@@ -156,7 +156,7 @@ ___TEMPLATE_PARAMETERS___
             ]
           }
         ],
-        "help": "If you are using Google Consent Mode or Stape\u0027s Data Tag to transmit consent to the server, then enable this setting to use the consent information from them.\n\u003cbr\u003e\nThis field has precedence over the \u003cb\u003eAwin Consent Signal\u003c/b\u003e."
+        "help": "If you are using Google Consent Mode or Stape\u0027s Data Tag to transmit consent to the server, then enable this setting to use the consent information from them.\n\u003cbr\u003e\nThis field has precedence over the \u003cb\u003eAwin Consent Signal\u003c/b\u003e.\n\u003cbr\u003e\nAny conflicting values between these fields will result in denied consent."
       },
       {
         "type": "TEXT",
@@ -171,7 +171,7 @@ ___TEMPLATE_PARAMETERS___
             ]
           }
         ],
-        "help": "Accepted values are: 0,1,true,false.\n\u003cbr\u003eIf any other values are passed, or the field is left blank, the tag will assume \u003ci\u003etrue\u003c/i\u003e was specified.\n\u003cbr\u003e\nThe \u003cb\u003eautomatic consent detection checkbox\u003c/b\u003e, if marked, has precedence over the this field."
+        "help": "Accepted values are: 0,1,true,false.\n\u003cbr\u003e\nIf any other values are passed, or the field is left blank, the tag will assume \u003ci\u003etrue\u003c/i\u003e was specified.\n\u003cbr\u003e\nThe \u003cb\u003eautomatic consent detection checkbox\u003c/b\u003e, if marked, has precedence over the this field.\n\u003cbr\u003e\nAny conflicting values between these fields will result in denied consent."
       },
       {
         "type": "CHECKBOX",
@@ -1011,7 +1011,7 @@ scenarios:
 
     // Verify that the tag finished successfully.
     assertApi('gtmOnSuccess').wasCalled();
-- name: Improving PLT (product level tracking) data > Using the user defined PLT object
+- name: PLT (product level tracking) data > Using the user defined PLT object
   code: "const testFlag = '#PRODUCT_OVERRIDE_TEST#';\nconst productsOverride = testFlag\
     \ + '[{\"item_id\":\"SKU_12345\",\"item_name\":\"Stan and Friends Tee | aijsdiasjdijas\
     \ | aisjdiajsd piee |||| kajsdkajsd ||aasd\",\"affiliation\":\"Google Merchandise\


### PR DESCRIPTION
Hi.

I've added the changes required by the **Awin template needed updates** document.

Some important notes:

1. Added a field to check consent from Awin Data Tag or GA4 tags, which has precedence over the native **Awin Consent Signal** field. Remember that, by default, the tag considers the default consent status as `true`. This was maintained in this PR.
2. I added a fallback for reading the new `awin_sn_awc` cookie from the Data Tag. I will make a PR updating it (https://github.com/stape-io/data-tag/blob/main/template.js#L443-L444).
3. Added a field to exempt **Cashback and Rewards Journeys** from consent restrictions. i.e., checks the presence of the `"sn=1"` query parameter.
4. When checking if the user-provided **Products Override** field is a string, I opted to check for the `eventData.items` as well.
5. The **Order Reference** sent both in "ref=" and in the PLT now uses the same logic of where to get the data from: `data.orderReference` >> `eventData.transaction_id`. In addition, the PLT fallbacks also to `item.order_reference` to accommodate a possible breaking change.
6. The **Custom Parameters** group now has a column where it's possible to add a **Key**. This added a breaking change. Therefore, for those users who update the template but do not add a Key, we assign a key on their behalf based on the order of the parameters in the template fields.

---

This is a helpful material to be used when testing the changes related to **Expanding the scope of the awin_awc cookie** and **Improving the consent framework**.

**Expanding the scope of the awin_awc cookie**

Query parameters:
?awc=12345-awc-12345&gclid=12345gclid123123&awaid=123123awaid123123
?awc=&gclid=no-awc-12345gclid123123&awaid=no-awc-123123awaid123123
?gclid=no-awc-12345gclid123123&awaid=no-awc-123123awaid123123
?awc=12345-awc-12345&gclid=12345gclid123123&awaid=123123awaid123123&sn=1
?awc=&gclid=no-awc-12345gclid123123&awaid=no-awc-123123awaid123123&sn=1
?gclid=no-awc-12345gclid123123&awaid=no-awc-123123awaid123123&sn=1


**Improving the consent framework**

`page_view` event
  - If URL contains "sn=1"
    - **Unconditional Cashback & Rewards Tracking** field is `enabled`
    Expected: creation of `awin_sn_awc` and `awin_source`
    - **Unconditional Cashback & Rewards Tracking** field is `disabled`
      - Go to  "else if URL doesn't contain "sn=1"
  - else if URL doesn't contain "sn=1"
    - Consent granted
    Expected: creation of `awin_awc` and `awin_source`
    - Consent not granted
    Expected: no cookie creation.

`purchase` event
  - if **Consent granted**
  Expected: reads `awin_awc` (go inside the "cks=" request parameter), `awin_sn_awc` (go inside the "cks=" request parameter) and `awin_source` (go inside the "ch=" request parameter)
  - else if **Consent not granted**
    - Enabled Unconditional Cashback & Rewards Tracking
    Expected: reads `awin_sn_awc` (go inside the "cks=" request parameter) and `awin_source` (go inside the "ch=" request parameter)
    - Disabled Unconditional Cashback & Rewards Tracking
    Expected: no cookie reading (parameters "cks=" and "ch=" remain empty)