### PR TITLE
Update template.js to set httpOnly:true when setting the awin_awc cookie

### DIFF
--- a/template.js
+++ b/template.js
@@ -45,7 +45,7 @@ switch (eventName) {
             domain: data.overridenCookieDomain || 'auto',
             path: '/',
             secure: true,
-            httpOnly: false,
+            httpOnly: true,
             'max-age': 31536000, // 1 year
           };
           
@@ -57,7 +57,7 @@ switch (eventName) {
             domain: data.overridenCookieDomain || 'auto',
             path: '/',
             secure: true,
-            httpOnly: false,
+            httpOnly: true,
             'max-age': 31536000, // 1 year
           };
           


### PR DESCRIPTION
Awin expects the cookie to have the httpOnly:true as per their doc https://developer.awin.com/docs/direct-s2s

I hope I'm not messing up the template, as I have never used github before. 
Apologies for any inconvenience