### PR TITLE
Add HttpOnly option when creating cookies

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,6 @@
 {
-    "singleQuote": true
+  "singleQuote": true,
+  "trailingComma": "none",
+  "tabWidth": 2,
+  "printWidth": 100
 }

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: 'https://stape.io/'
 versions:
+  - sha: 872dbfcfc4348f6c4cf45b945a0e9f10e4b6708a
+    changeNotes: Added HttpOnly flag option to cookies.
   - sha: 36c09751c354293319649ab03cc4ff36886ce2c2
     changeNotes: Improved consent framework, improved PLT tracking, improved custom parameters handling, added cookie domain override, added some tests.
   - sha: 80a94cf14d27ea976655f46e25c45a598afde6c8

--- a/template.tpl
+++ b/template.tpl
@@ -236,6 +236,13 @@ ___TEMPLATE_PARAMETERS___
         "help": "Enable this option to override the cookie domain.\n\u003cbr\u003e\nEnter your website\u0027s top-level domain as a fixed value (e.g., example.com).\n\u003cbr\u003e\nIf left unchecked, the domain will be automatically determined using the following priority:\n\u003cul\u003e\n\u003cli\u003eDomain of the \u003ci\u003eForwarded\u003c/i\u003e header (if present).\u003c/li\u003e\n\u003cli\u003eDomain of the \u003ci\u003eX-Forwarded-Host\u003c/i\u003e header (if present).\u003c/li\u003e\n\u003cli\u003eDomain of the \u003ci\u003eHost\u003c/i\u003e header.\u003c/li\u003e\n\u003c/ul\u003e"
       },
       {
+        "type": "CHECKBOX",
+        "name": "useHttpOnlyCookie",
+        "checkboxText": "Use HttpOnly cookies",
+        "simpleValueType": true,
+        "help": "Forbids JavaScript from accessing the cookie if enabled."
+      },
+      {
         "type": "GROUP",
         "name": "customParametersGroup",
         "displayName": "Custom Parameters",
@@ -357,6 +364,8 @@ const getContainerVersion = require('getContainerVersion');
 const getType = require('getType');
 const makeString = require('makeString');
 
+/**********************************************************************************************/
+
 const isLoggingEnabled = determinateIsLoggingEnabled();
 const traceId = getRequestHeader('trace-id');
 const eventData = getAllEventData();
@@ -371,67 +380,64 @@ if (url && url.lastIndexOf('https://gtm-msr.appspot.com/', 0) === 0) {
   return data.gtmOnSuccess();
 }
 
+/**********************************************************************************************/
+// Vendor related functions
+
 switch (eventName) {
   case PAGE_VIEW_EVENT:
     if (url) {
       const searchParams = parseUrl(url).searchParams;
-      const isJourneyExemptFromConsent = 
-         !!searchParams.sn && searchParams.sn === '1' && data.enableCashbackTracking;
+      const isJourneyExemptFromConsent =
+        !!searchParams.sn && searchParams.sn === '1' && data.enableCashbackTracking;
       const deduplicationParamName = data.deduplicationQueryParameterName || 'source';
-      
+
       if (isJourneyExemptFromConsent || !isConsentDeclined()) {
         if (searchParams.awc || (searchParams.awaid && searchParams.gclid)) {
-          const awcCookieName = isJourneyExemptFromConsent ? 'awin_sn_awc' : 'awin_awc'; 
-          const awcCookieValue = searchParams.awc 
-            ? searchParams.awc 
+          const awcCookieName = isJourneyExemptFromConsent ? 'awin_sn_awc' : 'awin_awc';
+          const awcCookieValue = searchParams.awc
+            ? searchParams.awc
             : 'gclid_' + searchParams.awaid + '_' + searchParams.gclid;
-          
+
           const options = {
             domain: data.overridenCookieDomain || 'auto',
             path: '/',
             secure: true,
-            httpOnly: false,
-            'max-age': 31536000, // 1 year
+            httpOnly: !!data.useHttpOnlyCookie,
+            'max-age': 31536000 // 1 year
           };
-          
+
           setCookie(awcCookieName, awcCookieValue, options, false);
         }
-       
+
         if (searchParams[deduplicationParamName]) {
           const options = {
             domain: data.overridenCookieDomain || 'auto',
             path: '/',
             secure: true,
-            httpOnly: false,
-            'max-age': 31536000, // 1 year
+            httpOnly: !!data.useHttpOnlyCookie,
+            'max-age': 31536000 // 1 year
           };
-          
-          setCookie(
-            'awin_source',
-            searchParams[deduplicationParamName],
-            options,
-            false
-          );
+
+          setCookie('awin_source', searchParams[deduplicationParamName], options, false);
         }
       }
     }
-    
+
     data.gtmOnSuccess();
     break;
   case PURCHASE_EVENT:
     const commonCookie = eventData.common_cookie || {};
-    
+
     let awc;
-    let source = data.channel || getCookieValues('awin_source')[0] || commonCookie.awin_source || 'aw';
-    
+    let source =
+      data.channel || getCookieValues('awin_source')[0] || commonCookie.awin_source || 'aw';
+
     if (!isConsentDeclined()) {
-      const awcFromCookie = 
-        [getCookieValues('awin_awc')[0], getCookieValues('awin_sn_awc')[0]]
-        .filter(cookieValue => !!cookieValue)
+      const awcFromCookie = [getCookieValues('awin_awc')[0], getCookieValues('awin_sn_awc')[0]]
+        .filter((cookieValue) => !!cookieValue)
         .join(',');
-      const awcFromCommonCookie = 
-        [commonCookie.awin_awc, commonCookie.awin_sn_awc]
-        .filter(cookieValue => !!cookieValue)
+      const awcFromCommonCookie = [commonCookie.awin_awc, commonCookie.awin_sn_awc]
+        .filter((cookieValue) => !!cookieValue)
         .join(',');
       awc = data.clickId || awcFromCookie || awcFromCommonCookie;
     } else if (data.enableCashbackTracking) {
@@ -440,29 +446,24 @@ switch (eventName) {
       // Do not read the cookies or use the template fields.
       awc = '';
       source = '';
-    }    
-    
+    }
+
     const orderReference = data.orderReference || eventData.transaction_id;
     let requestUrl =
-      'https://www.awin1.com/sread.php?tt=ss&tv=2&merchant=' +
-      enc(data.advertiserId);
+      'https://www.awin1.com/sread.php?tt=ss&tv=2&merchant=' + enc(data.advertiserId);
     requestUrl = requestUrl + '&amount=' + enc(data.totalAmount);
     requestUrl = requestUrl + '&ch=' + enc(source);
     requestUrl = requestUrl + '&vc=' + enc(data.voucherCode);
     requestUrl = requestUrl + '&cr=' + enc(data.currencyCode);
     requestUrl = requestUrl + '&ref=' + enc(orderReference);
-    requestUrl =
-      requestUrl + '&customeracquisition=' + enc(data.customerAcquisition);
+    requestUrl = requestUrl + '&customeracquisition=' + enc(data.customerAcquisition);
     requestUrl = requestUrl + '&testmode=' + (data.isTest ? 1 : 0);
     requestUrl = requestUrl + '&cks=' + enc(awc);
 
     /**
      * Commission Group
      */
-    if (
-      data.commissionGroup &&
-      (data.commissionGroup.indexOf(':') !== -1 || data.totalAmount)
-    ) {
+    if (data.commissionGroup && (data.commissionGroup.indexOf(':') !== -1 || data.totalAmount)) {
       const cg =
         data.commissionGroup.indexOf(':') !== -1
           ? data.commissionGroup
@@ -474,23 +475,23 @@ switch (eventName) {
     /**
      * Custom Parameters
      */
-    const customParameters = [ { key: '1', value: 'gtm_s2s_stape_' + getContainerVersion().containerId } ];
+    const customParameters = [
+      { key: '1', value: 'gtm_s2s_stape_' + getContainerVersion().containerId }
+    ];
     const allowedTypesForCustomParameters = ['string', 'number', 'boolean'];
     if (getType(data.customParameters) === 'array') {
       data.customParameters.forEach((customParameter, index) => {
-        customParameters.push({ 
-          // If user hasn't added the key because of the breaking change when the column was added, 
+        customParameters.push({
+          // If user hasn't added the key because of the breaking change when the column was added,
           // we assign it on their behalf based on the order of the parameters.
           // "key" must start at 1, and 1 is always the "gtm_s2s_stape_<Container ID>" param. So, we add 2 to the index.
-          key: customParameter.key ? customParameter.key : (index + 2), 
-          value: customParameter.value 
+          key: customParameter.key ? customParameter.key : index + 2,
+          value: customParameter.value
         });
       });
     }
     customParameters.forEach((customParameter) => {
-      if (
-        allowedTypesForCustomParameters.indexOf(getType(customParameter.value)) !== -1
-      ) {
+      if (allowedTypesForCustomParameters.indexOf(getType(customParameter.value)) !== -1) {
         requestUrl = requestUrl + '&p' + customParameter.key + '=' + enc(customParameter.value);
       }
     });
@@ -500,10 +501,10 @@ switch (eventName) {
      */
     let items = data.productsOverride || eventData.items || [];
     if (getType(items) === 'string') items = JSON.parse(items);
-    
+
     const productRow =
       'AW:P|{{advertiserId}}|{{orderReference}}|{{productId}}|{{productName}}|{{productItemPrice}}|{{productQuantity}}|{{productSku}}|{{commissionGroupCode}}|{{productCategory}}';
-    
+
     if (getType(items) === 'array') {
       items.forEach((item, index) => {
         let value = productRow.replace(
@@ -515,23 +516,11 @@ switch (eventName) {
           enc(orderReference || item.order_reference || '')
         );
         value = value.replace('{{productId}}', enc(item.item_id || ''));
-        value = value.replace(
-          '{{productName}}',
-          enc(replacePipeWithUnderscore(item.item_name))
-        );
-        value = value.replace(
-          '{{productItemPrice}}',
-          getPriceString(item.price)
-        );
+        value = value.replace('{{productName}}', enc(replacePipeWithUnderscore(item.item_name)));
+        value = value.replace('{{productItemPrice}}', getPriceString(item.price));
         value = value.replace('{{productQuantity}}', item.quantity || '');
-        value = value.replace(
-          '{{productSku}}',
-          enc(item.item_sku || item.item_id || '')
-        );
-        value = value.replace(
-          '{{commissionGroupCode}}',
-          item.commission_group_code || 'DEFAULT'
-        );
+        value = value.replace('{{productSku}}', enc(item.item_sku || item.item_id || ''));
+        value = value.replace('{{commissionGroupCode}}', item.commission_group_code || 'DEFAULT');
         value = value.replace(
           '{{productCategory}}',
           enc(replacePipeWithUnderscore(item.item_category))
@@ -548,7 +537,7 @@ switch (eventName) {
           TraceId: traceId,
           EventName: 'Conversion',
           RequestMethod: 'GET',
-          RequestUrl: requestUrl,
+          RequestUrl: requestUrl
         })
       );
     }
@@ -565,7 +554,7 @@ switch (eventName) {
               EventName: 'Conversion',
               ResponseStatusCode: statusCode,
               ResponseHeaders: headers,
-              ResponseBody: body,
+              ResponseBody: body
             })
           );
         }
@@ -584,6 +573,9 @@ switch (eventName) {
     break;
 }
 
+/**********************************************************************************************/
+// Helpers
+
 function isConsentDeclined() {
   const autoConsentParameter = data.consentAutoDetectionParameter;
   if (autoConsentParameter) {
@@ -591,7 +583,7 @@ function isConsentDeclined() {
     if (eventData.consent_state && eventData.consent_state[autoConsentParameter] === false) {
       return true;
     }
-      
+
     // Check consent state from Google Consent Mode
     const gcsPositionMapping = { analytics_storage: 3, ad_storage: 2 };
     const xGaGcs = eventData['x-ga-gcs'] || ''; // x-ga-gcs is a string like "G110"
@@ -599,7 +591,7 @@ function isConsentDeclined() {
       return true;
     }
   }
-  
+
   // Check template field specific consent signal
   const awinConsentSignal = makeString(data.awinConsentSignal || '');
   return ['0', 'false'].indexOf(awinConsentSignal) !== -1;
@@ -611,8 +603,7 @@ function replacePipeWithUnderscore(data) {
 }
 
 function enc(data) {
-  data = data || '';
-  return encodeUriComponent(data);
+  return encodeUriComponent((data = data || ''));
 }
 
 function getPriceString(price) {
@@ -1006,10 +997,60 @@ scenarios:
       else if (cookieSettings.domain !== mockData.overridenCookieDomain) fail('incorrect cookie domain');
     });
 
-    // Call runCode to run the template's code.
     runCode(mockData);
 
-    // Verify that the tag finished successfully.
+    assertApi('gtmOnSuccess').wasCalled();
+- name: Override cookie Http Only flag - Disabled
+  code: |-
+    const expectedUseHttpOnlyCookie = true;
+    const mockData = {
+      useHttpOnlyCookie: undefined
+    };
+
+    const page_location = 'https://example.com/?awc=awc123';
+
+    mock('getAllEventData', {
+      event_name: 'page_view',
+      page_location: page_location
+    });
+
+    mock('getEventData', (key) => {
+      if (key === 'page_location') return page_location;
+    });
+
+    mock('setCookie', (cookieName, cookieValue, cookieSettings) => {
+      if (['awin_source', 'awin_sn_awc', 'awin_awc'].indexOf(cookieName) === -1) fail('incorrect cookie name');
+      else if (cookieSettings.httpOnly !== false) fail('incorrect cookie http only flag');
+    });
+
+    runCode(mockData);
+
+    assertApi('gtmOnSuccess').wasCalled();
+- name: Override cookie Http Only flag - Enabled
+  code: |-
+    const expectedUseHttpOnlyCookie = true;
+    const mockData = {
+      useHttpOnlyCookie: expectedUseHttpOnlyCookie
+    };
+
+    const page_location = 'https://example.com/?awc=awc123';
+
+    mock('getAllEventData', {
+      event_name: 'page_view',
+      page_location: page_location
+    });
+
+    mock('getEventData', (key) => {
+      if (key === 'page_location') return page_location;
+    });
+
+    mock('setCookie', (cookieName, cookieValue, cookieSettings) => {
+      if (['awin_source', 'awin_sn_awc', 'awin_awc'].indexOf(cookieName) === -1) fail('incorrect cookie name');
+      else if (cookieSettings.httpOnly !== true) fail('incorrect cookie http only flag');
+    });
+
+    runCode(mockData);
+
     assertApi('gtmOnSuccess').wasCalled();
 - name: PLT (product level tracking) data > Using the user defined PLT object
   code: "const testFlag = '#PRODUCT_OVERRIDE_TEST#';\nconst productsOverride = testFlag\
@@ -1142,5 +1183,4 @@ setup: const logToConsole = require('logToConsole');
 ___NOTES___
 
 Created on 10/11/2021, 09:29:27
-
 


### PR DESCRIPTION
Hi.

As raised here https://github.com/stape-io/awin-tag/pull/16, I have added support for `HttpOnly` cookies, if the user wants to set them with this flag.

I also run Prettier in the `template.js` file, that's why there are a lot of changes.
However, the true changes are [this](https://github.com/stape-io/awin-tag/blob/88c800faf2d583412fb507fd2ff6e00c906763f1/template.js#L53) and [this](https://github.com/stape-io/awin-tag/blob/88c800faf2d583412fb507fd2ff6e00c906763f1/template.js#L65).