### PR TITLE
Fix missing SameSite=None attribute for AWIN server-to-server cookies

### DIFF
--- a/template.js
+++ b/template.js
@@ -49,6 +49,7 @@ switch (eventName) {
           const options = {
             domain: data.overridenCookieDomain || 'auto',
             path: '/',
+            samesite: 'none',
             secure: true,
             httpOnly: !!data.useHttpOnlyCookie,
             'max-age': 31536000 // 1 year
@@ -61,6 +62,7 @@ switch (eventName) {
           const options = {
             domain: data.overridenCookieDomain || 'auto',
             path: '/',
+            samesite: 'none',
             secure: true,
             httpOnly: !!data.useHttpOnlyCookie,
             'max-age': 31536000 // 1 year

--- a/template.tpl
+++ b/template.tpl
@@ -401,6 +401,7 @@ switch (eventName) {
           const options = {
             domain: data.overridenCookieDomain || 'auto',
             path: '/',
+            samesite: 'none',
             secure: true,
             httpOnly: !!data.useHttpOnlyCookie,
             'max-age': 31536000 // 1 year
@@ -413,6 +414,7 @@ switch (eventName) {
           const options = {
             domain: data.overridenCookieDomain || 'auto',
             path: '/',
+            samesite: 'none',
             secure: true,
             httpOnly: !!data.useHttpOnlyCookie,
             'max-age': 31536000 // 1 year


### PR DESCRIPTION
**Problem**

When using the AWIN Tag template for server-side GTM, the following cookies are set:

- ServerAwinChannelCookie
- aw_sn_awc
- awin_source

Even though the server responds with Set-Cookie, these cookies are not visible under Application → Storage → Cookies in the browser.

This happens because the cookies are created without the SameSite=None attribute, which modern browsers (Chrome, Safari, Edge) block by default for cross-domain cookies.

As a result, AWIN’s diagnostics show:

Issues with the Server-to-Server Cookie
The first-party cookie for Server-to-Server tracking could not be found. If this transaction came via an affiliate link, please make sure that the Server-to-Server cookie is set.

**Solution**

This PR updates the template so that cookies are set with:

```
'samesite': 'none',
'secure': true
```

This ensures compatibility with modern browser cookie policies and fixes the issue where AWIN server-to-server tracking cannot detect first-party cookies.

Impact

- Fixes AWIN diagnostics error about missing cookies.
- Ensures `ServerAwinChannelCookie`, `aw_sn_awc`, and `awin_source` are properly set and visible in browser storage.
- Improves reliability of affiliate tracking across Shopify and other ecommerce setups using server-side GTM.